### PR TITLE
fix: 퍼블리케이션/강의 연도 필터 검증 및 Today 라벨

### DIFF
--- a/src/components/YearFilter.tsx
+++ b/src/components/YearFilter.tsx
@@ -24,6 +24,19 @@ const YearFilter: React.FC<YearFilterProps> = ({
   availableTypes,
   typeLabel = "Publication Type"
 }) => {
+  // Start에는 endYear 이하만, End에는 startYear 이상만 표시 (Start > End 선택 불가)
+  const startYearOptions = React.useMemo(() => {
+    if (!endYear) return availableYears
+    const end = parseInt(endYear, 10)
+    return availableYears.filter(y => parseInt(y, 10) <= end)
+  }, [availableYears, endYear])
+
+  const endYearOptions = React.useMemo(() => {
+    if (!startYear) return availableYears
+    const start = parseInt(startYear, 10)
+    return availableYears.filter(y => parseInt(y, 10) >= start)
+  }, [availableYears, startYear])
+
   return (
     <div className="mb-2 md:mb-6">
       <div className="bg-gray-50 rounded-lg p-1.5 md:p-4">
@@ -62,8 +75,8 @@ const YearFilter: React.FC<YearFilterProps> = ({
                   onChange={(e) => onStartYearChange(e.target.value)}
                   className="px-1 py-0.5 bg-white border border-gray-300 rounded-md text-xs font-normal text-gray-600 focus:outline-none focus:border-blue-400 hover:border-blue-300 transition-all duration-300 min-w-[70px] md:min-w-[100px]"
                 >
-                  <option value="">All</option>
-                  {availableYears.map((year) => (
+                  <option value="">Today</option>
+                  {startYearOptions.map((year) => (
                     <option key={year} value={year}>
                       {year}
                     </option>
@@ -81,8 +94,8 @@ const YearFilter: React.FC<YearFilterProps> = ({
                   onChange={(e) => onEndYearChange(e.target.value)}
                   className="px-1 py-0.5 bg-white border border-gray-300 rounded-md text-xs font-normal text-gray-600 focus:outline-none focus:border-blue-400 hover:border-blue-300 transition-all duration-300 min-w-[70px] md:min-w-[100px]"
                 >
-                  <option value="">All</option>
-                  {availableYears.map((year) => (
+                  <option value="">Today</option>
+                  {endYearOptions.map((year) => (
                     <option key={year} value={year}>
                       {year}
                     </option>

--- a/src/pages/lectures.tsx
+++ b/src/pages/lectures.tsx
@@ -47,14 +47,31 @@ const LecturesPage: React.FC<PageProps<DataProps>> = ({ data }) => {
     )
   }
 
+  // 연도 변경 시 Start > End 되지 않도록 반대쪽 자동 보정
+  const handleStartYearChange = (year: string) => {
+    setStartYear(year)
+    if (year && endYear && parseInt(year, 10) > parseInt(endYear, 10)) {
+      setEndYear(year)
+    }
+  }
+  const handleEndYearChange = (year: string) => {
+    setEndYear(year)
+    if (year && startYear && parseInt(year, 10) < parseInt(startYear, 10)) {
+      setStartYear(year)
+    }
+  }
+
   // 필터링된 강의들
   const filteredLectures = lectures.filter((lecture) => {
     const lectureType = getTypeFromMajor(lecture.frontmatter.major)
-    const lectureYear = new Date(lecture.frontmatter.date).getFullYear().toString()
-    
+    const yearNum = new Date(lecture.frontmatter.date).getFullYear()
+    if (Number.isNaN(yearNum)) return false
+
     const typeMatch = selectedTypes.length === 0 || selectedTypes.includes(lectureType)
-    const yearMatch = (!startYear || lectureYear >= startYear) && (!endYear || lectureYear <= endYear)
-    
+    const startNum = startYear ? parseInt(startYear, 10) : 0
+    const endNum = endYear ? parseInt(endYear, 10) : 9999
+    const yearMatch = yearNum >= startNum && yearNum <= endNum
+
     return typeMatch && yearMatch
   })
 
@@ -73,8 +90,8 @@ const LecturesPage: React.FC<PageProps<DataProps>> = ({ data }) => {
         <YearFilter
           startYear={startYear}
           endYear={endYear}
-          onStartYearChange={setStartYear}
-          onEndYearChange={setEndYear}
+          onStartYearChange={handleStartYearChange}
+          onEndYearChange={handleEndYearChange}
           selectedTypes={selectedTypes}
           onTypeChange={handleTypeToggle}
           availableTypes={availableTypes}

--- a/src/pages/publications.tsx
+++ b/src/pages/publications.tsx
@@ -57,12 +57,26 @@ const PublicationsPage: React.FC<PageProps<DataProps>> = ({ data }) => {
     )
   }
 
+  // 연도 변경 시 Start > End 되지 않도록 반대쪽 자동 보정
+  const handleStartYearChange = (year: string) => {
+    setStartYear(year)
+    if (year && endYear && parseInt(year, 10) > parseInt(endYear, 10)) {
+      setEndYear(year)
+    }
+  }
+  const handleEndYearChange = (year: string) => {
+    setEndYear(year)
+    if (year && startYear && parseInt(year, 10) < parseInt(startYear, 10)) {
+      setStartYear(year)
+    }
+  }
+
   // 필터링된 논문 목록
   const filteredPublications = React.useMemo(() => {
     return publications.filter(pub => {
       const year = parseInt(pub.frontmatter.year)
-      const start = startYear ? parseInt(startYear) : 0
-      const end = endYear ? parseInt(endYear) : 9999
+      const start = startYear ? parseInt(startYear, 10) : 0
+      const end = endYear ? parseInt(endYear, 10) : 9999
       const typeMatch = selectedTypes.length === 0 || selectedTypes.includes(pub.frontmatter.type)
       return year >= start && year <= end && typeMatch
     })
@@ -92,8 +106,8 @@ const PublicationsPage: React.FC<PageProps<DataProps>> = ({ data }) => {
           startYear={startYear}
           endYear={endYear}
           selectedTypes={selectedTypes}
-          onStartYearChange={setStartYear}
-          onEndYearChange={setEndYear}
+          onStartYearChange={handleStartYearChange}
+          onEndYearChange={handleEndYearChange}
           onTypeChange={handleTypeToggle}
           availableYears={availableYears}
           availableTypes={availableTypes}


### PR DESCRIPTION
- Start > End 선택 불가: 옵션 제한 + 변경 시 반대쪽 자동 보정
- 필터 빈 값 라벨 All → Today 로 변경
- 연도 비교 숫자화 및 parseInt radix 통일

Made with [Cursor](https://cursor.com)