### PR TITLE
feat: 퍼블 타임라인 abbrev·연도 필터 개선

### DIFF
--- a/content/publications/Dataset-on-Takeover-During-Distracted-L2-Automated-Driving.md
+++ b/content/publications/Dataset-on-Takeover-During-Distracted-L2-Automated-Driving.md
@@ -13,5 +13,6 @@ abstract: |
   Automated driving systems enable drivers to perform various non-driving tasks, raising safety concerns related to distraction and takeover performance. However, publicly available datasets on this topic are scarce. This study introduces TD2D, a rich dataset collected from 50 drivers using an L2 automated driving simulator, balanced in gender and age. The dataset includes 500 takeover cases across 10 conditions—spanning no task, visual, and auditory secondary tasks. It provides data on takeover performance, workload, physiological signals, and ocular measures. TD2D offers a significant contribution to advancing research in safe automated driving and intelligent driver monitoring systems.
 paper: "/paper/A_Dataset_on_Takeover_during_Distracted_L2_Automated_Driving.pdf"
 slide: ""
+abbrev: "Sci. Data"
 github: "https://github.com/HAI-lab-KNU/TD2D_SupplementaryCodes"
 ---

--- a/content/publications/Driver-vehicle-flow-control.md
+++ b/content/publications/Driver-vehicle-flow-control.md
@@ -9,6 +9,7 @@ doi: ""
 paper: "/paper/ICTC20_FlowControl.pdf"
 slide: ""
 video: ""
+abbrev: "ICTC"
 ---
 
 # Towards Flow Control of Driver-Vehicle Interactions

--- a/content/publications/Effects-of-In-Vehicle-Auditory-Interactions.md
+++ b/content/publications/Effects-of-In-Vehicle-Auditory-Interactions.md
@@ -12,4 +12,5 @@ abstract: |
   In SAE Level 2 semi-automated driving environments, auditory secondary tasks—though not visually or manually distracting—can reduce takeover performance. This study examined how different levels of auditory task difficulty impact driver reaction during takeover events. Using a driving simulator and physiological monitoring of 50 participants, the research found that auditory tasks significantly influenced takeover quality. Moreover, physiological signals such as pupil diameter, eye movement dispersion, and inter-beat interval were associated with takeover performance. The findings suggest potential for real-time systems to estimate cognitive load and manage interruptions more intelligently.
 paper: "/paper/IJHCS_smartCar.pdf"
 slide: ""
+abbrev: "IJHCS"
 ---

--- a/content/publications/Endpoint-device-risk-scoring.md
+++ b/content/publications/Endpoint-device-risk-scoring.md
@@ -9,6 +9,7 @@ doi: "10.3390/electronics12081906"
 paper: "/paper/electronics23_ZeroTrust.pdf"
 slide: ""
 video: ""
+abbrev: "Electronics"
 ---
 
 # Endpoint Device Risk-Scoring Algorithm Proposal for Zero Trust

--- a/content/publications/Exploring-Context-Aware-Mental-Health-Self-Tracking.md
+++ b/content/publications/Exploring-Context-Aware-Mental-Health-Self-Tracking.md
@@ -12,5 +12,6 @@ abstract: |
 paper: "/paper/CHI24Multimodal.pdf"
 slide: ""
 video: "https://www.youtube.com/watch?v=GqpiW3gaO4s"
+abbrev: "CHI"
 tags: ["Top Conference"]
 ---

--- a/content/publications/HCIK23_smartCar.md
+++ b/content/publications/HCIK23_smartCar.md
@@ -10,6 +10,7 @@ doi: "https://www.dbpia.co.kr/Journal/articleDetail?nodeId=NODE11527339"
 paper: "/paper/HCIK23_smartCar.pdf"
 slide: ""
 video: ""
+abbrev: "HCIK"
 ---
 
 # 2단계 자율주행 중 시각 및 청각 이차 과제 수행이 제어권 전환 능력에 미치는 영향

--- a/content/publications/Interrupting-for-Microlearning.md
+++ b/content/publications/Interrupting-for-Microlearning.md
@@ -14,5 +14,6 @@ abstract: |
 paper: "/paper/CHI24Microlearning.pdf"
 slide: ""
 video: "https://www.youtube.com/watch?v=JBZ-uJym3hg"
+abbrev: "CHI"
 tags: ["Top Conference"]
 ---

--- a/content/publications/IoT-Enabled-Patch-with-Microsensors.md
+++ b/content/publications/IoT-Enabled-Patch-with-Microsensors.md
@@ -13,4 +13,5 @@ abstract: |
   This study developed and evaluated an IoT-enabled patch with built-in microsensors and a wireless chip to enable real-time, remote monitoring of adherence during patch treatment for amblyopia. The patch uses dual temperature sensors to detect wear status and transmits data to a cloud server every 15 seconds via a mobile application. The system was validated in two experiments with 30 adults and 40 children, showing high accuracy and usability. The results demonstrate that this technology can support clinicians in monitoring treatment adherence objectively and adjusting plans in real-time.
 paper: "/paper/TVST2024.pdf"
 slide: ""
+abbrev: "TVST"
 ---

--- a/content/publications/K-EmoCon.md
+++ b/content/publications/K-EmoCon.md
@@ -9,6 +9,7 @@ doi: "10.1038/s41597-020-00630-y"
 paper: "/paper/scientific20_K_Emocon.pdf"
 slide: ""
 video: ""
+abbrev: "Sci. Data"
 ---
 
 # K-EmoCon, a Multimodal Sensor Dataset for Continuous Emotion Recognition in Naturalistic Conversations

--- a/content/publications/K-EmoPhone.md
+++ b/content/publications/K-EmoPhone.md
@@ -9,6 +9,7 @@ doi: "10.1038/s41597-023-02248-2"
 paper: "/paper/scientfic23KEmoPhone.pdf"
 slide: ""
 video: ""
+abbrev: "Sci. Data"
 ---
 
 # K-EmoPhone: A Mobile and Wearable Dataset with In-Situ Emotion, Stress, and Attention Labels

--- a/content/publications/Low-cost-level3-simulator.md
+++ b/content/publications/Low-cost-level3-simulator.md
@@ -10,6 +10,7 @@ doi: "https://www.dbpia.co.kr/journal/articleDetail?nodeId=NODE11043827"
 paper: "/paper/HCIK22_simulater.pdf"
 slide: ""
 video: ""
+abbrev: "HCIK"
 ---
 
 # Developing and Evaluating Low-Cost Level 3 Vehicle Simulator

--- a/content/publications/Mobile-ESM-emotion-changes.md
+++ b/content/publications/Mobile-ESM-emotion-changes.md
@@ -9,6 +9,7 @@ doi: "10.1145/3491102.3501944"
 paper: "/paper/CHI22_ESM.pdf"
 slide: ""
 video: "https://www.youtube.com/watch?v=CCw1uEOuhZM"
+abbrev: "CHI"
 tags: ["Top Conference"]
 ---
 

--- a/content/publications/Mobile-contact-tracing.md
+++ b/content/publications/Mobile-contact-tracing.md
@@ -9,6 +9,7 @@ doi: "10.3389/fpubh.2021.586615"
 paper: "/paper/frontiers21_covid19.pdf"
 slide: ""
 video: ""
+abbrev: "Frontiers"
 ---
 
 # Benefits of Mobile Contact Tracing on COVID-19: Tracing Capacity Perspectives

--- a/content/publications/S-ADL-Exploring-Smartphone-Based-Activities-of-Daily-Living.md
+++ b/content/publications/S-ADL-Exploring-Smartphone-Based-Activities-of-Daily-Living.md
@@ -13,5 +13,6 @@ abstract: |
 paper: "/paper/CHI24SADL.pdf"
 slide: ""
 video: "https://www.youtube.com/watch?v=X4jMDuCoaOA"
+abbrev: "CHI"
 tags: ["Top Conference"]
 ---

--- a/content/publications/Smart-speaker-timing.md
+++ b/content/publications/Smart-speaker-timing.md
@@ -9,6 +9,7 @@ doi: "10.1145/3411810"
 paper: "/paper/IMWUT20_smartspeaker.pdf"
 slide: ""
 video: "https://www.youtube.com/watch?v=0G-XhcPJNiw"
+abbrev: "IMWUT"
 tags: ["Top Conference"]
 ---
 

--- a/content/publications/Sticky-goals.md
+++ b/content/publications/Sticky-goals.md
@@ -9,6 +9,7 @@ doi: "10.1145/3411764.3445295"
 paper: "/paper/CHI21_commitments.pdf"
 slide: ""
 video: "https://www.youtube.com/watch?v=mSCXgOceCpA"
+abbrev: "CHI"
 tags: ["Top Conference"]
 ---
 

--- a/content/publications/Voice-driving-assistance-agent.md
+++ b/content/publications/Voice-driving-assistance-agent.md
@@ -10,6 +10,7 @@ doi: "https://www.dbpia.co.kr/Journal/articleDetail?nodeId=NODE11043828"
 paper: "/paper/HCIK22_intelligentVehicleAgent.pdf"
 slide: ""
 video: ""
+abbrev: "HCIK"
 ---
 
 # A Survey on Design for Development of Voice Driving Assistance Agent

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -124,7 +124,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       paper: String
       slide: String
       video: String
-      thumbnail: String
+      abbrev: String
       image1: String
       image2: String
       image3: String

--- a/src/components/PublicationTimeline.tsx
+++ b/src/components/PublicationTimeline.tsx
@@ -1,0 +1,298 @@
+import * as React from "react"
+import { createPortal } from "react-dom"
+import { Link } from "gatsby"
+
+export type PublicationNode = {
+  id: string
+  fields?: { slug: string }
+  frontmatter: {
+    title: string
+    journal: string
+    type: string
+    year: string
+    doi?: string
+    paper?: string
+    abbrev?: string
+  }
+}
+
+type PublicationTimelineProps = {
+  publications: PublicationNode[]
+}
+
+const TYPE_COLORS: Record<string, { bg: string; label: string }> = {
+  Journal: { bg: "bg-blue-200", label: "Journal" },
+  Conference: { bg: "bg-orange-200", label: "Conference" },
+  Poster: { bg: "bg-slate-200", label: "Poster" },
+}
+
+function getShortLabel(journal: string): string {
+  if (!journal) return "—"
+  const j = journal.trim()
+  if (j.length <= 18) return j
+  return j.split(/[\s,&]+/)[0]?.slice(0, 10) || "—"
+}
+
+function getDisplayLabel(pub: PublicationNode): string {
+  if (pub.frontmatter.abbrev?.trim()) return pub.frontmatter.abbrev.trim()
+  return getShortLabel(pub.frontmatter.journal)
+}
+
+const PublicationTimeline: React.FC<PublicationTimelineProps> = ({ publications }) => {
+  const [hoveredPub, setHoveredPub] = React.useState<PublicationNode | null>(null)
+  const [hoveredEl, setHoveredEl] = React.useState<HTMLElement | null>(null)
+  const [triggerRect, setTriggerRect] = React.useState<DOMRect | null>(null)
+  const scrollRef = React.useRef<HTMLDivElement>(null)
+  const [showScrollHint, setShowScrollHint] = React.useState(false)
+  const hasScrolledToEndRef = React.useRef(false)
+
+  React.useEffect(() => {
+    if (!hoveredEl) {
+      setTriggerRect(null)
+      return
+    }
+    const update = () => setTriggerRect(hoveredEl.getBoundingClientRect())
+    update()
+    window.addEventListener("scroll", update, true)
+    window.addEventListener("resize", update)
+    return () => {
+      window.removeEventListener("scroll", update, true)
+      window.removeEventListener("resize", update)
+    }
+  }, [hoveredEl])
+
+  const updateScrollHint = React.useCallback(() => {
+    const el = scrollRef.current
+    if (!el) return
+    const canScroll = el.scrollWidth > el.clientWidth
+    const atEnd = el.scrollLeft + el.clientWidth >= el.scrollWidth - 8
+    setShowScrollHint(canScroll && atEnd)
+    if (canScroll && !hasScrolledToEndRef.current) {
+      hasScrolledToEndRef.current = true
+      el.scrollLeft = el.scrollWidth
+    }
+  }, [])
+
+  React.useEffect(() => {
+    updateScrollHint()
+    const el = scrollRef.current
+    if (!el) return
+    const raf = requestAnimationFrame(() => updateScrollHint())
+    const ro = new ResizeObserver(updateScrollHint)
+    ro.observe(el)
+    el.addEventListener("scroll", updateScrollHint, { passive: true })
+    return () => {
+      cancelAnimationFrame(raf)
+      ro.disconnect()
+      el.removeEventListener("scroll", updateScrollHint)
+    }
+  }, [updateScrollHint])
+
+  const { yearOrder, byYear } = React.useMemo(() => {
+    const byYear: Record<string, PublicationNode[]> = {}
+    publications.forEach((pub) => {
+      const y = pub.frontmatter.year
+      if (!y) return
+      if (!byYear[y]) byYear[y] = []
+      byYear[y].push(pub)
+    })
+    const yearOrder = Object.keys(byYear).sort((a, b) => parseInt(a, 10) - parseInt(b, 10))
+    return { yearOrder, byYear }
+  }, [publications])
+
+  if (yearOrder.length === 0) return null
+
+  return (
+    <div className="mb-6 md:mb-8">
+      <div className="relative">
+        <div
+          ref={scrollRef}
+          className="p-3 sm:p-4 md:p-6 overflow-x-auto -mx-1 sm:mx-0 scroll-smooth"
+          style={{ scrollbarGutter: "stable" }}
+        >
+          {/* 범례: 위에 유지, 모바일에서만 오른쪽 정렬(최신 먼저 보일 때 보이도록), 글자+상자 */}
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mb-2 text-xs text-gray-600 justify-end md:justify-start">
+            {Object.entries(TYPE_COLORS).map(([type, { bg, label }]) => (
+              <span key={type} className="inline-flex items-center gap-1">
+                <span className={`w-3.5 h-3.5 sm:w-4 sm:h-4 rounded-sm ${bg} flex-shrink-0`} aria-hidden />
+                <span>{label}</span>
+              </span>
+            ))}
+          </div>
+          {/* Timeline: 연도별 컬럼 */}
+          <div
+            className="grid gap-x-4 sm:gap-x-6 md:gap-x-8 min-w-max"
+            style={{
+              gridTemplateColumns: `repeat(${yearOrder.length}, minmax(72px, 1fr))`,
+              gridTemplateRows: "auto 1px auto",
+            }}
+          >
+          {yearOrder.map((year) => {
+            const items = byYear[year]
+            return (
+              <React.Fragment key={year}>
+                {/* 블록 영역: 행마다 링크(사각형+라벨) + 호버 카드 */}
+                <div className="flex flex-col justify-end gap-1.5">
+                  {items.map((pub) => {
+                    const typeStyle = TYPE_COLORS[pub.frontmatter.type] ?? TYPE_COLORS.Conference
+                    const short = getDisplayLabel(pub)
+                    const content = (
+                      <>
+                        <div className="min-w-0" aria-hidden />
+                        <div className="min-h-[1rem] flex items-center justify-center">
+                          <span
+                            className={`w-3.5 h-3.5 sm:w-4 sm:h-4 rounded-sm flex-shrink-0 ${typeStyle.bg}`}
+                            aria-hidden
+                          />
+                        </div>
+                        <div className="min-h-[1rem] flex items-center min-w-0 pl-1">
+                          <span
+                            className="text-xs text-gray-700 truncate max-w-[56px] sm:max-w-[80px] md:max-w-[120px] leading-4 group-hover:text-blue-600"
+                            aria-label={`${pub.frontmatter.title} (${pub.frontmatter.journal})`}
+                          >
+                            {short}
+                          </span>
+                        </div>
+                      </>
+                    )
+                    const cellClass =
+                      "grid grid-cols-[1fr_1.5rem_1fr] sm:grid-cols-[1fr_2rem_1fr] grid-rows-1 min-h-0 items-end gap-0 group relative " +
+                      (pub.frontmatter.paper || pub.frontmatter.doi || pub.fields?.slug ? "cursor-pointer" : "")
+
+                    const mouseProps = {
+                      onMouseEnter: (e: React.MouseEvent<HTMLElement>) => {
+                        setHoveredEl(e.currentTarget)
+                        setHoveredPub(pub)
+                      },
+                      onMouseLeave: () => {
+                        setHoveredEl(null)
+                        setHoveredPub(null)
+                      },
+                    }
+
+                    // PDF 버튼과 동일: paper/doi는 <a target="_blank">, 상세 페이지만 <Link>
+                    if (pub.frontmatter.paper) {
+                      return (
+                        <a
+                          key={pub.id}
+                          href={pub.frontmatter.paper}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className={cellClass}
+                          {...mouseProps}
+                        >
+                          {content}
+                        </a>
+                      )
+                    }
+                    if (pub.frontmatter.doi) {
+                      const doiUrl = pub.frontmatter.doi.startsWith("http")
+                        ? pub.frontmatter.doi
+                        : `https://doi.org/${pub.frontmatter.doi}`
+                      return (
+                        <a
+                          key={pub.id}
+                          href={doiUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className={cellClass}
+                          {...mouseProps}
+                        >
+                          {content}
+                        </a>
+                      )
+                    }
+                    if (pub.fields?.slug) {
+                      return (
+                        <Link key={pub.id} to={pub.fields.slug} className={cellClass} {...mouseProps}>
+                          {content}
+                        </Link>
+                      )
+                    }
+                    return (
+                      <div key={pub.id} className={cellClass} {...mouseProps}>
+                        {content}
+                      </div>
+                    )
+                  })}
+                </div>
+              </React.Fragment>
+            )
+          })}
+          {/* 가로선: 모든 연도 축 바로 위 한 줄 */}
+          <div
+            className="col-span-full h-px"
+            style={{
+              background: "linear-gradient(90deg, transparent 0%, rgb(203 213 225) 2%, rgb(203 213 225) 98%, transparent 100%)",
+            }}
+            aria-hidden
+          />
+          {yearOrder.map((year) => {
+            const items = byYear[year]
+            return (
+              <div key={year} className="flex flex-col items-center pt-1">
+                <span className="w-px h-3 bg-gray-300 flex-shrink-0" aria-hidden />
+                <span className="text-xs font-medium text-gray-600 mt-1">{year}</span>
+                <span className="text-[10px] text-gray-400">({items.length})</span>
+              </div>
+            )
+          })}
+        </div>
+        </div>
+        {/* 스크롤 가능 시 왼쪽에 표시 (과거 쪽으로 스크롤하라는 투명 화살표) */}
+        {showScrollHint && (
+          <div
+            className="absolute left-2 top-1/2 -translate-y-1/2 pointer-events-none flex items-center text-gray-400/60"
+            aria-hidden
+          >
+            <span className="text-lg font-light tracking-tight" style={{ textShadow: "0 0 8px white" }}>
+              ‹ ‹
+            </span>
+          </div>
+        )}
+      </div>
+      {/* 호버 카드 포털: 잘림 방지, 투명 배경, 퍼블 목록과 어울리는 스타일 */}
+      {(typeof document !== "undefined" && hoveredPub && triggerRect
+        ? createPortal(
+          (() => {
+            const maxW = 520
+            const minW = 280
+            const w = Math.min(maxW, Math.max(minW, window.innerWidth - 32))
+            const half = w / 2
+            const left = Math.max(
+              16,
+              Math.min(triggerRect.left + triggerRect.width / 2 - half, window.innerWidth - w - 16)
+            )
+            const top = triggerRect.top - 8
+            return (
+              <div
+                className="fixed z-[9999] px-3 py-2 rounded-lg shadow-lg border border-gray-200/70 whitespace-normal text-left pointer-events-none transition-opacity duration-150"
+                style={{
+                  left,
+                  top,
+                  width: w,
+                  minWidth: minW,
+                  maxWidth: maxW,
+                  transform: "translateY(-100%)",
+                  background: "rgba(248, 250, 252, 0.48)",
+                  backdropFilter: "blur(10px)",
+                  WebkitBackdropFilter: "blur(10px)",
+                }}
+              >
+                <div className="flex items-baseline gap-2 flex-wrap">
+                  <span className="text-xs font-medium text-blue-600 shrink-0">PDF preprint</span>
+                  <span className="text-base font-normal text-gray-900 break-words leading-snug">
+                    “{hoveredPub.frontmatter.title}”
+                  </span>
+                </div>
+              </div>
+            )
+          })(),
+          document.body
+        )
+        : null) as React.ReactNode}
+    </div>
+  )
+}
+
+export default PublicationTimeline

--- a/src/components/YearFilter.tsx
+++ b/src/components/YearFilter.tsx
@@ -75,7 +75,6 @@ const YearFilter: React.FC<YearFilterProps> = ({
                   onChange={(e) => onStartYearChange(e.target.value)}
                   className="px-1 py-0.5 bg-white border border-gray-300 rounded-md text-xs font-normal text-gray-600 focus:outline-none focus:border-blue-400 hover:border-blue-300 transition-all duration-300 min-w-[70px] md:min-w-[100px]"
                 >
-                  <option value="">Today</option>
                   {startYearOptions.map((year) => (
                     <option key={year} value={year}>
                       {year}

--- a/src/pages/publications.tsx
+++ b/src/pages/publications.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import { graphql, PageProps, Link } from "gatsby"
 import Layout from "../components/layout"
 import YearFilter from "../components/YearFilter"
+import PublicationTimeline from "../components/PublicationTimeline"
 import { FaMedal, FaFilePdf, FaPlay } from "react-icons/fa"
 import Seo from "../components/seo"
 
@@ -24,6 +25,7 @@ type DataProps = {
         paper: string
         slide: string
         video: string
+        abbrev?: string
         award?: string
       }
     }[]
@@ -32,13 +34,18 @@ type DataProps = {
 
 const PublicationsPage: React.FC<PageProps<DataProps>> = ({ data }) => {
   const publications = data.allMarkdownRemark.nodes
-  const [startYear, setStartYear] = React.useState<string>("")
+  const [startYear, setStartYear] = React.useState<string>(() => {
+    const years = [...new Set(publications.map(p => p.frontmatter.year).filter((y): y is string => y != null && y !== ""))]
+    if (years.length === 0) return ""
+    years.sort((a, b) => parseInt(a, 10) - parseInt(b, 10))
+    return years[0]
+  })
   const [endYear, setEndYear] = React.useState<string>("")
   const [selectedTypes, setSelectedTypes] = React.useState<string[]>([])
 
-  // 사용 가능한 연도 목록 생성 (최신순)
+  // 사용 가능한 연도 목록 생성 (최신순, 유효한 연도만)
   const availableYears = React.useMemo(() => {
-    const years = [...new Set(publications.map(pub => pub.frontmatter.year))].sort((a, b) => parseInt(b) - parseInt(a))
+    const years = [...new Set(publications.map(pub => pub.frontmatter.year).filter((y): y is string => y != null && y !== ""))].sort((a, b) => parseInt(b, 10) - parseInt(a, 10))
     return years
   }, [publications])
 
@@ -101,6 +108,9 @@ const PublicationsPage: React.FC<PageProps<DataProps>> = ({ data }) => {
     <Layout activeLink="Publications">
       <div className="max-w-7xl mx-auto px-3 md:px-8 py-6 md:py-8">
         <div className="space-y-8">
+        {/* 연도·유형별 시각화 (필터 위) */}
+        <PublicationTimeline publications={publications} />
+
         {/* 연도 필터 */}
         <YearFilter
           startYear={startYear}
@@ -239,6 +249,7 @@ export const query = graphql`
           paper
           slide
           video
+          abbrev
           award
           tags
         }


### PR DESCRIPTION
## 요약
- 퍼블 타임라인: 논문 클릭 시 paper 링크 우선, 호버 시 포털 툴팁(PDF preprint+제목)
- 타임라인 라벨을 md `abbrev` 필드로 통일 (HCIK, IMWUT, CHI 등), 하드코딩 제거
- 좁은 화면에서 최신 연도 먼저 노출, 스크롤 힌트(‹‹)
- 범례 위 유지, 모바일만 오른쪽 정렬, 상자+글자 순서, Conference 주황 파스텔
- 연도 필터: Start에서 Today 제거, Start 기본값 = 데이터 기준 가장 오래된 연도, availableYears 빈값 제거
- gatsby-node Frontmatter에 `abbrev` 추가, 논문 md에 abbrev 필드 추가

Made with [Cursor](https://cursor.com)