### PR TITLE
fix(ci): npm ci → npm install --legacy-peer-deps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
           node-version: '18' # Node.js 버전 설정 (Gatsby 호환 버전)
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install --legacy-peer-deps
 
       - name: Build Gatsby site
         run: npm run build # Gatsby 사이트 빌드


### PR DESCRIPTION
## Summary

- CI에서 `npm ci` 사용 시 `@shadergradient/react` → Next.js 의존성의 플랫폼별 optional 패키지가 macOS lock 파일에 누락되어 Ubuntu CI 실패하는 문제 수정
- `npm install --legacy-peer-deps`로 변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)